### PR TITLE
remove status in Show model, replace with available property

### DIFF
--- a/models/Show.js
+++ b/models/Show.js
@@ -6,7 +6,7 @@ const Show = db.define("shows", {
     title: DataTypes.STRING,
     genre: DataTypes.ENUM("Comedy", "Drama", "Horror", "Sitcom"),
     rating: DataTypes.INTEGER,
-    status: DataTypes.STRING,
+    available: DataTypes.BOOLEAN,
 });
 
 //exports


### PR DESCRIPTION
The seed data and instructions refer to an 'available' boolean property on a Show, but the Show model still refers to a 'status' string property. 